### PR TITLE
nextcloud miner: list all users

### DIFF
--- a/ciacco/miners/nextcloudsize-list
+++ b/ciacco/miners/nextcloudsize-list
@@ -47,7 +47,6 @@ my $i = 0;
 open(my $fh, "du -b --max-depth=1 -c /var/lib/nethserver/nextcloud/ 2>/dev/null| sort -n -r |");
 while (readline($fh)) {
     $i++;
-    next if ($i <= 3); # skip total lines
     my ($bytes, $dir) = split(/\s+/, $_);
     my $name = basename($dir);
     if ($users->{$name}) {


### PR DESCRIPTION
The du output contains only 2 lines of totals.
Also the check is not need really needed because lines are
later joined with the list of users.

Thanks to Francesco Zei

NethServer/dev#6034