### PR TITLE
ciacco: execute jobs in parallel mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
         "
 before_install:
     - sudo apt-get install curl python-software-properties npm python-setuptools -y
-    - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-    -  sudo apt-get install nodejs
+    - curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+    - sudo apt-get install nodejs
     - sudo npm config set ca ""
     - sudo npm conf set strict-ssl false
     - sudo easy_install pip

--- a/caronte/package.json
+++ b/caronte/package.json
@@ -13,6 +13,7 @@
   "author": "Edoardo Spadoni <edoardo.spadoni@nethesis.it>",
   "license": "ISC",
   "dependencies": {
+    "globby": "https://github.com/sindresorhus/globby/tarball/5eb9015c1166065115876ed7f4992f64727d7c1b",
     "i18n": "^0.8.3",
     "mjml": "^4.4.0-beta.2",
     "moment": "^2.24.0",

--- a/ciacco/ciacco
+++ b/ciacco/ciacco
@@ -32,6 +32,6 @@ fi
 TODAY_DIR="$CIACCO_OUTPUT_DIR/""$(date +"%Y/%m/%d")/"
 mkdir -p $TODAY_DIR
 
-/usr/bin/find /usr/share/dante/miners -type f -executable | /usr/bin/parallel /usr/share/dante/ciacco/miner_exec $TODAY_DIR {}
+/usr/bin/find /usr/share/dante/miners -type f -executable | /usr/bin/parallel --will-cite /usr/share/dante/ciacco/miner_exec $TODAY_DIR {}
 
 exit 0

--- a/ciacco/miner_exec
+++ b/ciacco/miner_exec
@@ -31,7 +31,7 @@ MINER=$2
 NAME=$(basename $MINER)
 OUT="$DIR/$NAME".json
 
-$2 > $OUT
+$MINER > $OUT
 if [ $? -gt 0 ]; then
     rm -f $OUT
 fi

--- a/ciacco/miner_exec
+++ b/ciacco/miner_exec
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2019 Nethesis S.r.l.
+# Copyright (C) 2021 Nethesis S.r.l.
 # http://www.nethesis.it - info@nethesis.it
 #
 # This script is part of Dante.
@@ -20,18 +20,18 @@
 # along with Dante.  If not, see COPYING.
 #
 
-# Execute all Dante miners and save the output to the configured directory.
+#
+# Execute a miner and save the output on a JSON file
+# If the miner exists non-zero, the output file will be removed
+#
 
-CIACCO_OUTPUT_DIR=/var/lib/nethserver/dante
-CIACCO_MINERS_DIR=/usr/share/dante/miners
+DIR=$1
+MINER=$2
 
-if [ -f /etc/sysconfig/dante ]; then
-    . /etc/sysconfig/dante
+NAME=$(basename $MINER)
+OUT="$DIR/$NAME".json
+
+$2 > $OUT
+if [ $? -gt 0 ]; then
+    rm -f $OUT
 fi
-
-TODAY_DIR="$CIACCO_OUTPUT_DIR/""$(date +"%Y/%m/%d")/"
-mkdir -p $TODAY_DIR
-
-/usr/bin/find /usr/share/dante/miners -type f -executable | /usr/bin/parallel /usr/share/dante/ciacco/miner_exec $TODAY_DIR {}
-
-exit 0

--- a/dist/dante.spec
+++ b/dist/dante.spec
@@ -23,6 +23,8 @@ Source7:    dante.conf
 BuildRequires: systemd
 BuildRequires: python
 
+Requires: parallel
+
 %description
 Single stack reports made simple
 
@@ -44,6 +46,7 @@ python -m compileall ciacco/lib/squidguard.py
 %install
 mkdir -p %{buildroot}/usr/share/dante/beatrice
 mkdir -p %{buildroot}/usr/share/dante/virgilio
+mkdir -p %{buildroot}/usr/share/dante/ciacco
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/etc/sysconfig/
 mkdir -p %{buildroot}/etc/cron.d/
@@ -53,6 +56,7 @@ mkdir -p %{buildroot}/%{python_sitelib}
 mv ciacco/lib/squidguardlib.py* %{buildroot}%{python_sitelib}
 rm -rf ciacco/lib/
 cp ciacco/ciacco %{buildroot}/%{_bindir}
+cp ciacco/miner_exec %{buildroot}/usr/share/dante/ciacco
 cp %{SOURCE1} %{buildroot}/%{_bindir}
 cp %{SOURCE4} %{buildroot}/%{_bindir}
 mv ciacco/miners %{buildroot}/usr/share/dante/
@@ -79,6 +83,7 @@ cp %{SOURCE7} %{buildroot}/etc/httpd/conf.d/
 %{python_sitelib}/squidguardlib.py*
 /usr/share/dante/miners/
 /usr/share/dante/beatrice
+/usr/share/dante/ciacco/miner_exec
 
 
 %changelog


### PR DESCRIPTION
On machines with big logs, the execution can take long time:
all jobs executed after midnight will report invalid data.

Execute all miners in parallel to prevent such scenario.

NethServer/dev#6419