### PR TITLE
miners: support ntopng4

### DIFF
--- a/ciacco/miners/hosttraffic-chart-bar
+++ b/ciacco/miners/hosttraffic-chart-bar
@@ -25,40 +25,32 @@ use warnings;
 use JSON;
 use File::Basename;
 
-my $api = 'http://127.0.0.1:3000/lua/hosts_traffic.lua';
+my $api = 'http://127.0.0.1:3000/lua/rest/v1/get/host/custom_data.lua?ifid=view:all&field_alias=ip,names,local_network_id,bytes.sent,bytes.rcvd';
 my $limit = 10;
-my $content = {};
+my @hosts;
 my @categories;
 my @sent;
 my @received;
 my $i = 0;
 
-system("/usr/bin/curl -s '$api' | grep '^{' > /tmp/result_ntopng_chart_bar");
-
-my $json;
-{
-  open my $fh, "<", "/tmp/result_ntopng_chart_bar";
-  $json = <$fh>;
-  close $fh;
-  system("/bin/rm -f /tmp/result_ntopng_chart_bar");
-}
-
-if ($json) {
-   $content = decode_json($json);
-} else {
-    exit 1;
-}
+my $content = decode_json(`/usr/bin/curl -s -H 'Content-Type: application/json' '$api'`);
 
 if (!$content) {
     exit 1;
 }
 
-foreach my $key (sort { int($a) <=> int($b) } keys %{$content->{'rank'}}) {
-    my $ip = $content->{'rank'}{$key};
+foreach my $host (@{$content->{'rsp'}}) {
+    next if not exists $host->{'local_network_id'};
+    push(@hosts, {"host" => $host->{'ip'}, "sent" => int($host->{'bytes.sent'}), "rcvd" => int($host->{'bytes.rcvd'}), "tot" => int($host->{'bytes.sent'}) + int($host->{'bytes.rcvd'})});
+}
+
+@hosts = sort { $a->{"tot"} <=> $b->{"tot"}; } @hosts;
+
+foreach (reverse @hosts) {
     last if ($i >= $limit);
-    push(@categories, $ip);
-    push(@sent,  $content->{'hosts'}{$ip}{'total'}{'sent'});
-    push(@received,  $content->{'hosts'}{$ip}{'total'}{'received'});
+    push(@categories, $_->{"host"});
+    push(@sent, $_->{'sent'});
+    push(@received, $_->{'rcvd'});
     $i++;
 }
 

--- a/ciacco/miners/hosttraffic-table
+++ b/ciacco/miners/hosttraffic-table
@@ -1,64 +1,33 @@
 #!/usr/bin/perl
 
-#
-# Copyright (C) 2019 Nethesis S.r.l.
-# http://www.nethesis.it - info@nethesis.it
-#
-# This script is part of Dante.
-#
-# Dante is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License,
-# or any later version.
-#
-# Dante is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Dante.  If not, see COPYING.
-#
-
-#
-# hosttraffic-table - a miner to collect data about host traffic
-#
 use strict;
 use warnings;
 use JSON;
 
-my $api = 'http://127.0.0.1:3000/lua/hosts_traffic.lua';
+my $api = 'http://127.0.0.1:3000/lua/rest/v1/get/host/custom_data.lua?ifid=view:all&field_alias=ip,names,local_network_id,bytes.sent,bytes.rcvd';
 my $limit = 10;
 my $i = 0;
 my @data;
-my $content = {};
 my @rows;
 
-system("/usr/bin/curl -s '$api' | grep '^{' > /tmp/result_ntopng");
-
-my $json;
-{
-  open my $fh, "<", "/tmp/result_ntopng";
-  $json = <$fh>;
-  close $fh;
-  system("/bin/rm -f /tmp/result_ntopng");
-}
-
-if ($json) {
-   $content = decode_json($json);
-} else {
-    exit 1;
-}
+my $content = decode_json(`/usr/bin/curl -H 'Content-Type: application/json' -s '$api'`);
 
 if (!$content) {
     exit 1;
 }
 
-foreach my $key (sort { int($a) <=> int($b) } keys %{$content->{'rank'}}) {
-    my $ip = $content->{'rank'}{$key};
+my @hosts;
+foreach my $host (@{$content->{'rsp'}}) {
+    next if not exists $host->{'local_network_id'};
+    push(@hosts, {"host" => $host->{'ip'}, "sent" => int($host->{'bytes.sent'}), "rcvd" => int($host->{'bytes.rcvd'}), "tot" => int($host->{'bytes.sent'}) + int($host->{'bytes.rcvd'})});
+}
+
+@hosts = sort { $a->{"tot"} <=> $b->{"tot"}; } @hosts;
+
+foreach (reverse @hosts) {
     last if ($i >= $limit);
-    push(@rows, $ip);
-    push(@data, [ $content->{'hosts'}{$ip}{'total'}{'sent'}, $content->{'hosts'}{$ip}{'total'}{'received'} ]);
+    push(@rows, $_->{"host"});
+    push(@data, [$_->{"sent"}, $_->{"rcvd"}]);
     $i++;
 }
 


### PR DESCRIPTION
Old host traffic miners were using a custom lua script for ntopng.
Such script can't be ported to ntopng 4.
The miners have been rewritten to use a new ntopng 4 API.
Please be aware that traffic report is always relative
to last ntopng start.

Nethesis/dev#6024

Alternative solution #21 